### PR TITLE
Fix source code mutation in WITH-NESTING

### DIFF
--- a/grid3.lisp
+++ b/grid3.lisp
@@ -151,10 +151,10 @@
                  do (funcall function element))))
 
 (defmacro with-nesting (&body body)
-  (when (rest body)
-    (setf (cdr (last (first body)))
-          `((with-nesting ,@(rest body)))))
-  (first body))
+  (destructuring-bind (first . rest) body
+    (if rest
+        (append first `((with-nesting ,@rest)))
+        first)))
 
 (defmethod call-with-contained (function (grid grid) (region region))
   (declare (optimize speed (safety 1)))


### PR DESCRIPTION
Instead of mutating `body`, build a new form with `append`.
I noticed the problem because a `with-nesting` macro call kept inserting more and more copies of my body form.