### PR TITLE
Add missing WITH-VEC4

### DIFF
--- a/quadtree.lisp
+++ b/quadtree.lisp
@@ -1,5 +1,14 @@
 (in-package #:org.shirakumo.fraf.trial.space.quadtree)
 
+(defmacro with-vec4 ((x y z w) vector &body body)
+  (let ((nvector (gensym "VECTOR")))
+    `(let* ((,nvector ,vector)
+            (,x (vx ,nvector))
+            (,y (vy ,nvector))
+            (,z (vz ,nvector))
+            (,w (vw ,nvector)))
+       ,@body)))
+
 (declaim (inline make-object-vector))
 (defun make-object-vector (&optional (initial-size 4))
   (make-array initial-size :adjustable T :fill-pointer 0))


### PR DESCRIPTION
Probably missing as a result of d9689b9965f5a4e6ef3d2bf7df9162b3f4438431.